### PR TITLE
chore(deps): update lucid ORM version

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "peerDependencies": {
     "@adonisjs/core": "^6.2.2",
-    "@adonisjs/lucid": "^20.1.0",
+    "@adonisjs/lucid": "^21.0.1",
     "@adonisjs/session": "^7.1.1",
     "reflect-metadata": "^0.2.1"
   },


### PR DESCRIPTION
Lucid ORM version is outdated, mentioned on #5. Tested on my own project after `npm run build` and works fine. Thanks for creating this package.