### PR TITLE
feat: extend filter conditions for string, textarea, and richtext types

### DIFF
--- a/src/adapter/resource.ts
+++ b/src/adapter/resource.ts
@@ -156,7 +156,11 @@ class Resource extends BaseResource {
 
       if (property.type() === 'uuid' || property.isId() || property.type() === 'boolean') {
         query.where(key, filterElement.value as string)
-      } else if (property.type() === 'string') {
+      } else if (
+        property.type() === 'string' ||
+        property.type() === 'textarea' ||
+        property.type() === 'richtext'
+      ) {
         const dialect = this.databaseType()
 
         if (dialect === 'postgres') {


### PR DESCRIPTION
This PR extends the existing filtering logic for `string` properties to also support `textarea` and `richtext` types. As a result, users can now search for substrings within these fields, enhancing the flexibility of text-based filtering.